### PR TITLE
Add config

### DIFF
--- a/__tests__/config.ts
+++ b/__tests__/config.ts
@@ -1,4 +1,9 @@
-import { breakpoints, resetBreakpoints, setBreakpoints } from '../src/config'
+import {
+	breakpoints,
+	extendBreakpoints,
+	resetBreakpoints,
+	setBreakpoints,
+} from '../src/config'
 
 const defaults = {
 	xxSmall: expect.any(Number),
@@ -10,17 +15,19 @@ const defaults = {
 	xxLarge: expect.any(Number),
 }
 
+const bespoke = { tiny: 5 }
+
 describe('breakpoints', () => {
 	test('are defaults without doing anything', () => {
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})
-	test('can be updated by user', () => {
-		setBreakpoints({ tiny: 5 })
-		expect(breakpoints).toEqual({ tiny: 5 })
-	})
-
-	test('can be reset to default', () => {
-		setBreakpoints({ tiny: 5 })
+	test('can be extended, replaced and reset', () => {
+		extendBreakpoints(bespoke)
+		expect(breakpoints).toEqual(
+			expect.objectContaining({ ...defaults, ...bespoke }),
+		)
+		setBreakpoints(bespoke)
+		expect(breakpoints).toEqual(bespoke)
 		resetBreakpoints()
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})

--- a/__tests__/config.ts
+++ b/__tests__/config.ts
@@ -1,0 +1,37 @@
+import { breakpoints, resetBreakpoints, setBreakpoints } from '../src/config'
+
+describe('breakpoints', () => {
+	test('are defaults without doing anything', () => {
+		expect(breakpoints).toEqual(
+			expect.objectContaining({
+				xxSmall: expect.any(Number),
+				xSmall: expect.any(Number),
+				small: expect.any(Number),
+				medium: expect.any(Number),
+				large: expect.any(Number),
+				xLarge: expect.any(Number),
+				xxLarge: expect.any(Number),
+			}),
+		)
+	})
+	test('can be updated by user', () => {
+		setBreakpoints({ tiny: 5 })
+		expect(breakpoints).toEqual({ tiny: 5 })
+	})
+
+	test('can be reset to default', () => {
+		setBreakpoints({ tiny: 5 })
+		resetBreakpoints()
+		expect(breakpoints).toEqual(
+			expect.objectContaining({
+				xxSmall: expect.any(Number),
+				xSmall: expect.any(Number),
+				small: expect.any(Number),
+				medium: expect.any(Number),
+				large: expect.any(Number),
+				xLarge: expect.any(Number),
+				xxLarge: expect.any(Number),
+			}),
+		)
+	})
+})

--- a/__tests__/config.ts
+++ b/__tests__/config.ts
@@ -1,18 +1,18 @@
 import { breakpoints, resetBreakpoints, setBreakpoints } from '../src/config'
 
+const defaults = {
+	xxSmall: expect.any(Number),
+	xSmall: expect.any(Number),
+	small: expect.any(Number),
+	medium: expect.any(Number),
+	large: expect.any(Number),
+	xLarge: expect.any(Number),
+	xxLarge: expect.any(Number),
+}
+
 describe('breakpoints', () => {
 	test('are defaults without doing anything', () => {
-		expect(breakpoints).toEqual(
-			expect.objectContaining({
-				xxSmall: expect.any(Number),
-				xSmall: expect.any(Number),
-				small: expect.any(Number),
-				medium: expect.any(Number),
-				large: expect.any(Number),
-				xLarge: expect.any(Number),
-				xxLarge: expect.any(Number),
-			}),
-		)
+		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})
 	test('can be updated by user', () => {
 		setBreakpoints({ tiny: 5 })
@@ -22,16 +22,6 @@ describe('breakpoints', () => {
 	test('can be reset to default', () => {
 		setBreakpoints({ tiny: 5 })
 		resetBreakpoints()
-		expect(breakpoints).toEqual(
-			expect.objectContaining({
-				xxSmall: expect.any(Number),
-				xSmall: expect.any(Number),
-				small: expect.any(Number),
-				medium: expect.any(Number),
-				large: expect.any(Number),
-				xLarge: expect.any(Number),
-				xxLarge: expect.any(Number),
-			}),
-		)
+		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})
 })

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -1,5 +1,0 @@
-import { x } from '../src/'
-
-test('tests exist', () => {
-	expect(x).toBe(true)
-})

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,18 @@
+const defaults = {
+	xxSmall: 320,
+	xSmall: 375,
+	small: 480,
+	medium: 740,
+	large: 980,
+	xLarge: 1140,
+	xxLarge: 1300,
+}
+
+let breakpoints: Breakpoints = defaults
+
+export const setBreakpoints = (userBreakpoints: Breakpoints) =>
+	(breakpoints = userBreakpoints)
+
+export const resetBreakpoints = () => (breakpoints = defaults)
+
+export { breakpoints }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,9 @@ const defaults = {
 
 let breakpoints: Breakpoints = defaults
 
+export const extendBreakpoints = (userBreakpoints: Breakpoints) =>
+	(breakpoints = Object.assign({}, userBreakpoints, breakpoints))
+
 export const setBreakpoints = (userBreakpoints: Breakpoints) =>
 	(breakpoints = userBreakpoints)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export const x = true
+import { resetBreakpoints, setBreakpoints } from './config'
+
+export { resetBreakpoints, setBreakpoints }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,3 @@
+type Breakpoints = {
+	[prop: string]: number
+}


### PR DESCRIPTION
Add breakpoint configs:

- provides default breakpoints
- user can extend defaults
- user can override defaults with their own
- user can reset to defaults