### PR TITLE
coerce the value to a string in tests

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -8,9 +8,13 @@ describe('until', () => {
 
 describe('from', () => {
 	test('is a weird old beast', () => {
-		expect(from.small.toString()).toBe('@media all and (min-width: 30em)')
-		expect(from.small.until.medium).toBe(
-			'@media all and (min-width: 30em) and (max-width: 46.1875em)',
-		)
+		// you woulnd't need to coerce the property to a
+		// string like this in JS, but you do in ts
+		expect({ [String(from.small)]: 'x' }).toEqual({
+			'@media all and (min-width: 30em)': 'x',
+		})
+		expect({ [from.small.until.medium]: 'x' }).toEqual({
+			'@media all and (min-width: 30em) and (max-width: 46.1875em)': 'x',
+		})
 	})
 })


### PR DESCRIPTION
rather than calling `toString()` explicitly