### PR TITLE
add support for custom media types

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -2,15 +2,29 @@ import { from, until } from '../src/index'
 
 describe('until', () => {
 	test('is an object that provides breakpoint media queries', () => {
-		expect(until.small).toBe('@media all and (max-width: 29.9375em)')
+		expect(`${until.small}`).toBe('@media all and (max-width: 29.9375em)')
 	})
 })
 
 describe('from', () => {
 	test('is a weird old beast', () => {
 		expect(`${from.small}`).toBe('@media all and (min-width: 30em)')
-		expect(from.small.until.medium).toBe(
+		expect(`${from.small.until.medium}`).toBe(
 			'@media all and (min-width: 30em) and (max-width: 46.1875em)',
+		)
+	})
+})
+
+describe('custom media', () => {
+	test('can be applied to `until`', () => {
+		expect(until.small.for('print')).toBe(
+			'@media print and (max-width: 29.9375em)',
+		)
+	})
+	test('can be applied to `from`', () => {
+		expect(from.small.for('print')).toBe('@media print and (min-width: 30em)')
+		expect(from.small.until.medium.for('print')).toBe(
+			'@media print and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,18 +7,27 @@ import {
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
-type Until = { [key in Breakpoints]: string }
+type Until = {
+	[key in Breakpoints]: {
+		toString: () => string
+		for: (arg0: string) => string
+	}
+}
 
 type From = {
 	[key in Breakpoints]: {
 		toString: () => string
 		until: Until
+		for: (arg0: string) => string
 	}
 }
 
 export const until = Object.entries(breakpoints).reduce(
 	(untils, [untilName, untilWidth]) => ({
-		[untilName]: untilQuery(untilWidth),
+		[untilName]: {
+			toString: () => untilQuery(untilWidth), // this piece of freaky genius by @SiAdcock
+			for: (type: string) => untilQuery(untilWidth, type),
+		},
 		...untils,
 	}),
 	{},
@@ -27,17 +36,21 @@ export const until = Object.entries(breakpoints).reduce(
 export const from = Object.entries(breakpoints).reduce(
 	(froms, [fromName, fromWidth], i) => ({
 		[fromName]: {
+			toString: () => fromQuery(fromWidth), // this piece of freaky genius by @SiAdcock
+			for: (type: string) => fromQuery(fromWidth, type),
 			until: Object.entries(breakpoints)
 				.splice(i + 1)
 				.reduce(
 					(untils, [untilName, untilWidth], i) => ({
-						[untilName]: fromUntilQuery(fromWidth, untilWidth),
+						[untilName]: {
+							toString: () => fromUntilQuery(fromWidth, untilWidth), // this piece of freaky genius by @SiAdcock
+							for: (type: string) =>
+								fromUntilQuery(fromWidth, untilWidth, type),
+						},
 						...untils,
 					}),
 					{},
 				),
-			// this piece of freaky genius by @SiAdcock
-			toString: () => fromQuery(fromWidth),
 		},
 		...froms,
 	}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const styles = {
 type Until = {
 	[key in Breakpoints]: {
 		toString: () => string
-		for: (arg0: string) => string
+		for: (mediaType: string) => string
 	}
 }
 
@@ -39,7 +39,7 @@ type From = {
 	[key in Breakpoints]: {
 		toString: () => string
 		until: Until
-		for: (arg0: string) => string
+		for: (mediaType: string) => string
 	}
 }
 
@@ -47,7 +47,7 @@ export const until = Object.entries(breakpoints).reduce(
 	(untils, [untilName, untilWidth]) => ({
 		[untilName]: {
 			toString: () => untilQuery(untilWidth),
-			for: (type: string) => untilQuery(untilWidth, type),
+			for: (mediaType: string) => untilQuery(untilWidth, mediaType),
 		},
 		...untils,
 	}),
@@ -58,15 +58,15 @@ export const from = Object.entries(breakpoints).reduce(
 	(froms, [fromName, fromWidth], i) => ({
 		[fromName]: {
 			toString: () => fromQuery(fromWidth),
-			for: (type: string) => fromQuery(fromWidth, type),
+			for: (mediaType: string) => fromQuery(fromWidth, mediaType),
 			until: Object.entries(breakpoints)
 				.splice(i + 1)
 				.reduce(
 					(untils, [untilName, untilWidth], i) => ({
 						[untilName]: {
 							toString: () => fromUntilQuery(fromWidth, untilWidth),
-							for: (type: string) =>
-								fromUntilQuery(fromWidth, untilWidth, type),
+							for: (mediaType: string) =>
+								fromUntilQuery(fromWidth, untilWidth, mediaType),
 						},
 						...untils,
 					}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,27 @@ import {
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
+/*
+`from` and `until` are objects with overridden `toString` methods,
+so that they can be coerced into media query strings _or_ provide
+further refinement of the query. this freaky genius was thought up
+by @SiAdcock.
+
+e.g.:
+
+const styles = {
+	[from.small]: {
+		color: 'red'
+	},
+	[from.small.until.large]: {
+		color: 'blue'
+	},
+	[from.small.until.large.for('print')]: {
+		color: 'black'
+	},
+}
+*/
+
 type Until = {
 	[key in Breakpoints]: {
 		toString: () => string
@@ -25,7 +46,7 @@ type From = {
 export const until = Object.entries(breakpoints).reduce(
 	(untils, [untilName, untilWidth]) => ({
 		[untilName]: {
-			toString: () => untilQuery(untilWidth), // this piece of freaky genius by @SiAdcock
+			toString: () => untilQuery(untilWidth),
 			for: (type: string) => untilQuery(untilWidth, type),
 		},
 		...untils,
@@ -36,14 +57,14 @@ export const until = Object.entries(breakpoints).reduce(
 export const from = Object.entries(breakpoints).reduce(
 	(froms, [fromName, fromWidth], i) => ({
 		[fromName]: {
-			toString: () => fromQuery(fromWidth), // this piece of freaky genius by @SiAdcock
+			toString: () => fromQuery(fromWidth),
 			for: (type: string) => fromQuery(fromWidth, type),
 			until: Object.entries(breakpoints)
 				.splice(i + 1)
 				.reduce(
 					(untils, [untilName, untilWidth], i) => ({
 						[untilName]: {
-							toString: () => fromUntilQuery(fromWidth, untilWidth), // this piece of freaky genius by @SiAdcock
+							toString: () => fromUntilQuery(fromWidth, untilWidth),
 							for: (type: string) =>
 								fromUntilQuery(fromWidth, untilWidth, type),
 						},


### PR DESCRIPTION
enables the following queries:

- `until.small.for('print')`
- `from.small.for('print')`
- `from.small.until.medium.for('print')`

