### PR TITLE
Make API require explicit calls

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-    trailingComma: 'all',
-    semi: false,
-    singleQuote: true,
-    useTabs: true,
-};
+	trailingComma: 'all',
+	semi: false,
+	singleQuote: true,
+	useTabs: true,
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ branches:
 script:
   - yarn lint
   - yarn global add codecov
-  - yarn test --ci
+  - yarn test --ci --coverage
 after_success:
   - codecov -f coverage/*.json

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Returns a media query scoped to:
 @media screen and (min-width: 30em) { ... }
 ```
 
-<hr />
-
 ### `until<breakpoint>`
 
 Type: `function`
@@ -86,8 +84,6 @@ Returns a media query scoped to:
 
 @media screen and (max-width: 61.1875em) { ... }
 ```
-
-<hr />
 
 ### `from<fromBreakpoint>.until<untilBreakpoint>`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # src-mq
 
-Legible breakpoints for JavaScript.
+_Legible breakpoints for JavaScript._
 
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ _Breakpoint values are output to CSS as ems, assuming 1em = 16px._
 
 ## Overriding breakpoints
 
-If the default breakpoints do not work for you, they can be replaced, extended or restored:
+The default breakpoints can be replaced, extended or restored:
 
 ```js
 import { setBreakpoints, extendBreakpoints, resetBreakpoints } from 'src-mq'

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Type: `Object.<breakpoint>`
 @media all and (min-width: 30em) { ... }
 ```
 
-#### Refinement
-
 The scope of the query can be restricted by chaining further refinements:
 
 ##### `.until`
@@ -73,8 +71,6 @@ Type: `Object.<breakpoint>`
 
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
-
-#### Refinement
 
 As with __from__, the scope of the query can be restricted by chaining a further refinement:
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,6 @@ const styles = {
 }
 ```
 
-## Defaults
-
-### Breakpoints
-
-- `xxSmall` (320 pixels)
-- `xSmall` (375 pixels)
-- `small` (480 pixels)
-- `medium` (740 pixels)
-- `large` (980 pixels)
-- `xLarge` (1140 pixels)
-- `xxLarge` (1300 pixels)
-
-_Breakpoint values are output to CSS as ems, assuming 1em = 16px._
-
-### Media type
-`@media all`
-
 ## API
 
 ### from
@@ -114,9 +97,25 @@ For example:
 @media speech and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
+## Defaults
+
+### Breakpoints
+
+- `xxSmall` (320 pixels)
+- `xSmall` (375 pixels)
+- `small` (480 pixels)
+- `medium` (740 pixels)
+- `large` (980 pixels)
+- `xLarge` (1140 pixels)
+- `xxLarge` (1300 pixels)
+
+_Breakpoint values are output to CSS as ems, assuming 1em = 16px._
+
+### Media type
+`@media all`
 
 
-## Customising breakpoints
+## Overriding defaults
 
 The default set of breakpoints can be replaced, extended or restored:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Set an explicit media type. See __for__ below.
 Type: `Object.<breakpoint>`
 
 - set a maximum width of __breakpoint__ − 1px
-- can be chained to the result of a __from__
+- can be chained to a __from__
 - when used as a string, it yields a media query
 
 ##### Example

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ const styles = {
 
 Type: `Object.<breakpoint>`
 
-Restricts styles to media as wide as or wider than __breakpoint__, for example:
+- set a minimum width of `breakpoint`
+- when used as a string, it yields a media query
+
+##### Example
 
 ```css
 /* {[from.small]: { ... }} */
@@ -37,25 +40,27 @@ Restricts styles to media as wide as or wider than __breakpoint__, for example:
 @media all and (min-width: 30em) { ... }
 ```
 
-When used without further refinement, it yields the media query we've constructed up to this point.
+#### Refinement
 
-#### Optional refinement
+The scope of the query can be restricted by chaining further refinements:
 
 ##### `.until`
 
-See __.until__ below.
+Set a maximum width. See __until__ below.
 
 ##### `.for`
 
-See __.for__ below.
+Set an explicit media type. See __for__ below.
 
-<hr />
-
-### `until` / `.until`
+### `until`
 
 Type: `Object.<breakpoint>`
 
-Restricts styles to media narrower than __breakpoint__, for example:
+- set a maximum width of __breakpoint__ − 1px
+- can be chained to the result of a __from__
+- when used as a string, it yields a media query
+
+##### Example
 
 ```css
 /* {[until.large]: { ... }} */
@@ -69,26 +74,26 @@ Restricts styles to media narrower than __breakpoint__, for example:
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-When used without further refinement, it yields the media query we've constructed up this point.
+#### Refinement
 
-#### Optional refinement
+As with __from__, the scope of the query can be restricted by chaining a further refinement:
 
 ##### `.for`
 
-Optional refinement of `fromBreakpointName`. See __.for__ below.
+Set an explicit media type. See __for__ below.
 
 
 ### `.for`
 
 Type: `Object.(screen | print | speech)`
 
-Overrides the default media type of `all`, and restricts styles to media of types:
+- can only be used as a refinment of __from__ or __until__
+- overrides the default media type (`all`), with any of the following:
+ - `screen`
+ - `print`
+ - `speech`
 
-- `screen`
-- `print`
-- `speech`
-
-For example:
+##### Example
 
 ```css
 /* {[from.small.for.screen]: { ... }} */

--- a/README.md
+++ b/README.md
@@ -31,12 +31,22 @@ Type: `function`
 
 Returns a media query that limits styles to media with a minimum width of **breakpoint**.
 
-```css
+```scss
 /* {[from.small()]: { ... }} */
 
-@media all and (min-width: 30em) {
-	...;
-}
+@media all and (min-width: 30em) { ... }
+```
+
+#### `from<breakpoint>.for[screen | print | speech]`
+
+Type: `function`
+
+Returns a media query that limits styles to media with a minimum width of **breakpoint** and the specified media type.
+
+```scss
+/* {[from.small.for.screen()]: { ... }} */
+
+@media screen and (min-width: 30em) { ... }
 ```
 
 #### `until<breakpoint>`
@@ -45,12 +55,22 @@ Type: `function`
 
 Returns a media query that limits styles to media with a maximum width of **breakpoint** − 1px.
 
-```css
+```scss
 /* {[until.large()]: { ... }} */
 
-@media all and (max-width: 61.1875em) {
-	...;
-}
+@media all and (max-width: 61.1875em) { ... }
+```
+
+#### `until<breakpoint>.for[screen | print | speech]`
+
+Type: `function`
+
+Returns a media query that limits styles to media with a maximum width of **breakpoint** − 1px and the specified media type.
+
+```scss
+/* {[until.large.for.screen()]: { ... }} */
+
+@media screen and (max-width: 61.1875em) { ... }
 ```
 
 #### `from<fromBreakpoint>.until<untilBreakpoint>`
@@ -59,45 +79,22 @@ Type: `function`
 
 Returns a media query that limits styles to media with a minimum width of **fromBreakpoint** and a maximum width of **untilBreakpoint** − 1px.
 
-```css
+```scss
 /* {[from.small.until.large()]: { ... }} */
 
-@media all and (min-width: 30em) and (max-width: 61.1875em) {
-	...;
-}
+@media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-#### `.for`
+#### `from<fromBreakpoint>.until<untilBreakpoint>.for[screen | print | speech]`
 
 Type: `function`
 
-- specifies the [media type](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_types)
-- can only be used when chained to a **from** or **until**
+Returns a media query that limits styles to media with a minimum width of **fromBreakpoint** and a maximum width of **untilBreakpoint** − 1px and the specified media type.
 
-##### Example
+```scss
+/* {[from.small.until.large.for.screen()]: { ... }} */
 
-```css
-/* {[from.small.for.screen()]: { ... }} */
-
-@media screen and (min-width: 30em) {
-	...;
-}
-```
-
-```css
-/* {[until.large.for.print()]: { ... }} */
-
-@media print and (max-width: 61.1875em) {
-	...;
-}
-```
-
-```css
-/* {[from.small.until.large.for.speech()]: { ... }} */
-
-@media speech and (min-width: 30em) and (max-width: 61.1875em) {
-	...;
-}
+@media screen and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
 ## Defaults
@@ -181,12 +178,10 @@ By design, _src-mq_ is limited to media type and min/max-width feature expressio
 
 To generate more complex queries than this, you can concatenate its output with any other valid feature expressions, for example:
 
-```css
+```scss
 /* {[from.small.for.screen() + " and (prefers-reduced-motion: reduce)"]: { ... }} */
 
-@media screen and (min-width: 30em) and (prefers-reduced-motion: reduce) {
-	...;
-}
+@media screen and (min-width: 30em) and (prefers-reduced-motion: reduce) { ... }
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const styles = {
 		
 		[from.small.until.large]: { ... },
 		
-		[from.small.until.large.for.print]: { ... },
+		[from.small.until.large.for.screen]: { ... },
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Breakpoint values are output as ems, assuming an em is 16 pixels.
 
 ## API
 
-### from[breakpoint]
+### from
 
-Apply rules from __breakpoint__ width, for example:
+Type: `Object.<breakpoint>`
+
+Restricts styles to media as wide as or wider than __breakpoint__, for example:
 
 ```css
 /* {[from.small]: { ... }} */
@@ -52,9 +54,22 @@ Apply rules from __breakpoint__ width, for example:
 @media all and (min-width: 30em) { ... }
 ```
 
-### until[breakpoint]
+When used without further refinement, it yields the media query we've constructed up to this point.
 
-Apply rules until one pixel before __breakpoint__ width, for example:
+##### until
+
+Optional refinement of `from.<breakpoint>`. See __until__ below.
+
+##### for
+
+Optional refinement of `from.<breakpoint>`. See __for__ below.
+
+
+### until
+
+Type: `Object.<breakpoint>`
+
+Restricts styles to media narrower than __breakpoint__, for example:
 
 ```css
 /* {[until.large]: { ... }} */
@@ -62,19 +77,24 @@ Apply rules until one pixel before __breakpoint__ width, for example:
 @media all and (max-width: 61.1875em) { ... }
 ```
 
-### from[breakpoint1].until[breakpoint2]
+When used without further refinement, it yields the media query we've constructed up this point.
 
-Apply rules between __breakpoint1__ width and one pixel before __breakpoint2__ width, for example:
+##### for
 
-```css
-/* {[from.small.until.large]: { ... }} */
+Optional refinement of `fromBreakpointName`. See __for__ below.
 
-@media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
-```
 
-### [ ... ].for[`screen`, `print`, `speech`]
+### for
 
-Apply rules for `screen`, `print` or `speech`, rather than the default `all`, for example:
+Type: `Object.(screen | print | speech)`
+
+Overrides the default media type of `all`, and restricts styles to media of types:
+
+- `screen`
+- `print`
+- `speech`
+
+For example:
 
 ```css
 /* {[from.small.for.screen]: { ... }} */

--- a/README.md
+++ b/README.md
@@ -1,7 +1,147 @@
-# src-mq 
+# src-mq
 
-> Breakpoint media queries in JS.
+Legible breakpoints for JavaScript.
 
-[![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq) 
+[![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)
 
+## Defaults
+
+### Breakpoints
+
+- `xxSmall` (320 pixels)
+- `xSmall` (375 pixels)
+- `small` (480 pixels)
+- `medium` (740 pixels)
+- `large` (980 pixels)
+- `xLarge` (1140 pixels)
+- `xxLarge` (1300 pixels)
+
+Breakpoint values are converted to ems, assuming an em is 16 pixels.
+
+### @media type
+The default is `all`.
+
+## Usage
+
+### Basics
+
+There are two main ways of applying breakpoints:
+
+- `from` (applies from `breakpoint.value`)
+- `until` (applies until `breakpoint.value - 1`)
+
+```js
+import { from, until } from 'src-mq'
+
+const styles = {
+
+	[until.medium]: {
+		color: 'green',
+	},
+
+	[from.large]: {
+		color: 'red',
+	},
+
+}
+```
+
+### Ranges
+
+`from` can also chain an `until`, to apply styles _between_ two breakpoints:
+
+```js
+import { from } from 'src-mq'
+
+const styles = {
+
+	[from.small.until.medium]: {
+		color: 'blue',
+	},
+
+}
+```
+
+### @media types
+
+Both techniques can chain an optional `for()` method, allowing you set a custom media type for an individual query:
+
+```js
+import { from, until } from 'src-mq'
+
+const styles = {
+
+	[until.medium.for('print')]: {
+		color: 'green',
+	},
+
+	[from.large.for('screen and print')]: {
+		color: 'red',
+	},
+
+}
+```
+
+## Custom breakpoints
+
+Breakpoints can be replaced, extended or restored:
+
+```js
+import {
+	setBreakpoints,
+	extendBreakpoints,
+	resetBreakpoints,
+} from 'src-mq'
+
+/*
+breakpoints are the default set:
+	- xxSmall (320 pixels)
+	- xSmall (375 pixels)
+	- small (480 pixels)
+	- medium (740 pixels)
+	- large (980 pixels)
+	- xLarge (1140 pixels)
+	- xxLarge (1300 pixels)
+*/
+
+setBreakpoints({ tiny: 1, massive: 10000000 })
+
+/*
+breakpoints have been replaced:
+	- tiny (1 pixel)
+	- massive (10000000 pixels)
+e.g. { [from.tiny.until.massive]: { … } }
+*/
+
+extendBreakpoints({ infinitesimal: 0.00000001 })
+
+/*
+breakpoints have been extended:
+	- infinitesimal (0.00000001 pixels)
+	- tiny (1 pixel)
+	- massive (10000000 pixels)
+e.g. { [from.infinitesimal.until.tiny]: { … } }
+*/
+
+resetBreakpoints()
+
+/*
+breakpoints have been restored to the default set:
+	- xxSmall (320 pixels)
+	- xSmall (375 pixels)
+	- small (480 pixels)
+	- medium (740 pixels)
+	- large (980 pixels)
+	- xLarge (1140 pixels)
+	- xxLarge (1300 pixels)
+*/
+```
+
+
+## Prior art
+`src-mq` is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
+
+It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) as part of the new rendering tier, and now being rolled into their [Source Design System](https://github.com/guardian/source-components).
+
+Hence the name 💃.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Returns a media query scoped to:
 
 Type: `function`
 
-Returns a media query that limits styles to media:
+Returns a media query scoped to:
 
 - a minimum width of **fromBreakpoint**
 - a maximum width of **untilBreakpoint** − 1px

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Breakpoint values are output as ems, assuming an em is 16 pixels.
 
 ## API
 
-### from.[breakpoint]
+### from[breakpoint]
 
 Apply rules from __breakpoint__ width, for example:
 
@@ -52,7 +52,7 @@ Apply rules from __breakpoint__ width, for example:
 @media all and (min-width: 30em) { ... }
 ```
 
-### until.[breakpoint]
+### until[breakpoint]
 
 Apply rules until one pixel before __breakpoint__ width, for example:
 
@@ -62,7 +62,7 @@ Apply rules until one pixel before __breakpoint__ width, for example:
 @media all and (max-width: 61.1875em) { ... }
 ```
 
-### from.[breakpoint1].until.[breakpoint2]
+### from[breakpoint1].until[breakpoint2]
 
 Apply rules from __breakpoint1__ width, until one pixel before __breakpoint2__ width, for example:
 
@@ -72,7 +72,7 @@ Apply rules from __breakpoint1__ width, until one pixel before __breakpoint2__ w
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-### [...].for.[`screen` | `print` | `speech`]
+### [...].for[`screen`, `print`, `speech`]
 
 Apply rules for `screen`, `print` or `speech`, rather than the default `all`, for example:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const styles = {
 
 Type: `Object.<breakpoint>`
 
-- set a minimum width of `breakpoint`
+- set a minimum width of __breakpoint__
 - when used as a string, it yields a media query
 
 ##### Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # src-mq
 
-🤓 Legible breakpoints for JavaScript.
+🤓 Lucid breakpoints for JavaScript.
 
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)

--- a/README.md
+++ b/README.md
@@ -12,21 +12,13 @@ import { from, until } from 'src-mq'
 
 const styles = {
 	p {
-		[from.small]: { 
-			content: "same as '@media all and (min-width: 30em)'"
-		},
+		[from.small]: { ... },
 		
-		[until.large]: { 
-			content: "same as ''"
-		},
+		[until.large]: { ... },
 		
-		[from.small.until.large]: { 
-			content: "same as '@media all and (min-width: 30em) and (max-width: 61.1875em)'"
-		},
+		[from.small.until.large]: { ... },
 		
-		[from.small.until.large.for.print]: { 
-			content: "same as '@media print and (min-width: 30em) and (max-width: 61.1875em)'"
-		},
+		[from.small.until.large.for.print]: { ... },
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const styles = {
 - `xLarge` (1140 pixels)
 - `xxLarge` (1300 pixels)
 
-Breakpoint values are output as ems, assuming an em is 16 pixels.
+_Breakpoint values are output to CSS as ems, assuming 1em = 16px._
 
 ### Media type
 `@media all`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,32 @@
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)
 
+### Example
+
+```js
+import { from, until } from 'src-mq'
+
+const styles = {
+	p {
+		[from.small]: { 
+			content: "same as '@media all and (min-width: 30em)'"
+		},
+		
+		[until.large]: { 
+			content: "same as ''"
+		},
+		
+		[from.small.until.large]: { 
+			content: "same as '@media all and (min-width: 30em) and (max-width: 61.1875em)'"
+		},
+		
+		[from.small.until.large.for.print]: { 
+			content: "same as '@media print and (min-width: 30em) and (max-width: 61.1875em)'"
+		},
+	}
+}
+```
+
 ## Defaults
 
 ### Breakpoints
@@ -17,73 +43,68 @@
 - `xLarge` (1140 pixels)
 - `xxLarge` (1300 pixels)
 
-_n.b. breakpoint values are converted to ems, assuming an em is 16 pixels._
+Breakpoint values are output as ems, assuming an em is 16 pixels.
 
-### @media type
-The default is `all`.
+### Media type
+`@media all`
 
-## Usage
+## API
 
-There are two ways of applying breakpoints:
+### from.[breakpoint]
 
-- `from`
-- `until`
+Apply rules from __breakpoint__, for example:
 
-```js
-import { from, until } from 'src-mq'
+```css
+/* {[from.small]: { ... }} */
 
-const styles = {
-
-	[until.medium]: {
-		color: 'green',
-	},
-
-	[from.large]: {
-		color: 'red',
-	},
-
-}
+@media all and (min-width: 30em) { ... }
 ```
 
-_n.b. `from`  applies from the breakpoint, `until` applies until the breakpoint minus one pixel._
+### until.[breakpoint]
 
-### Ranges
+Apply rules until one pixel before __breakpoint__, for example:
 
-`from` can also chain an `until`, to apply styles _between_ two breakpoints:
+```css
+/* {[until.large]: { ... }} */
 
-```js
-import { from } from 'src-mq'
-
-const styles = {
-
-	[from.small.until.medium]: {
-		color: 'blue',
-	},
-
-}
+@media all and (max-width: 61.1875em) { ... }
 ```
 
-### Custom @media types
+### from.[breakpoint1].until.[breakpoint2]
 
-Both techniques can chain an optional `for()` method, allowing you set a media type per query:
+Apply rules from __breakpoint1__ until one pixel before __breakpoint2__, for example:
 
-```js
-import { from, until } from 'src-mq'
+```css
+/* {[from.small.until.large]: { ... }} */
 
-const styles = {
-
-	[until.medium.for('print')]: {
-		color: 'green',
-	},
-
-	[from.large.for('screen and print')]: {
-		color: 'red',
-	},
-
-}
+@media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-## Using your own breakpoints
+### [...].for.[`screen` | `print` | `speech`]
+
+Apply rules for `screen`, `print` or `speech`, rather than the default `all`, for example:
+
+```css
+/* {[from.small.for.screen]: { ... }} */
+
+@media screen and (min-width: 30em) { ... }
+```
+
+```css
+/* {[until.large.for.print]: { ... }} */
+
+@media print and (min-width: 30em) { ... }
+```
+
+```css
+/* {[from.small.until.large.for.speech]: { ... }} */
+
+@media speech and (min-width: 30em) and (max-width: 61.1875em) { ... }
+```
+
+
+
+## Customising breakpoints
 
 The default set of breakpoints can be replaced, extended or restored:
 
@@ -147,6 +168,6 @@ resetBreakpoints()
 ## Acknowledgements
 _src-mq_ is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
 
-It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) that is now being rolled into their [Source Design System](https://github.com/guardian/source-components).
+It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) and that is now being rolled into their [Source Design System](https://github.com/guardian/source-components).
 
 Hence the name 💃.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Breakpoint values are output as ems, assuming an em is 16 pixels.
 
 ### from.[breakpoint]
 
-Apply rules from __breakpoint__, for example:
+Apply rules from __breakpoint__ width, for example:
 
 ```css
 /* {[from.small]: { ... }} */
@@ -54,7 +54,7 @@ Apply rules from __breakpoint__, for example:
 
 ### until.[breakpoint]
 
-Apply rules until one pixel before __breakpoint__, for example:
+Apply rules until one pixel before __breakpoint__ width, for example:
 
 ```css
 /* {[until.large]: { ... }} */
@@ -64,7 +64,7 @@ Apply rules until one pixel before __breakpoint__, for example:
 
 ### from.[breakpoint1].until.[breakpoint2]
 
-Apply rules from __breakpoint1__ until one pixel before __breakpoint2__, for example:
+Apply rules from __breakpoint1__ width, until one pixel before __breakpoint2__ width, for example:
 
 ```css
 /* {[from.small.until.large]: { ... }} */

--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ Type: `Object.(screen | print | speech)`
 
 ## Defaults
 
-### Breakpoints
+_src-mq_ provides a reasonable set of defaults:
+
+#### Media type
+`all`
+
+#### Breakpoints
 
 - `xxSmall` (320 pixels)
 - `xSmall` (375 pixels)
@@ -123,13 +128,10 @@ Type: `Object.(screen | print | speech)`
 
 _Breakpoint values are output to CSS as ems, assuming 1em = 16px._
 
-### Media type
-`@media all`
 
+## Overriding breakpoints
 
-## Overriding defaults
-
-The default set of breakpoints can be replaced, extended or restored:
+If the default breakpoints do not work for you, they can be replaced, extended or restored:
 
 ```js
 import {
@@ -188,9 +190,9 @@ resetBreakpoints()
 ```
 
 ## Complex queries
-By design, _src-mq_ is limited to media type and min/max-width expressions.
+By design, _src-mq_ is limited to media type and min/max-width feature expressions.
 
-To generate more complex queries than this, you can concatenate its output with any valid media feature expressions, for example:
+To generate more complex queries than this, you can concatenate its output with any other valid feature expressions, for example:
 
 ```css
 /* {[from.small + " and (prefers-reduced-motion: reduce)"]: { ... }} */

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const styles = {
 
 	[until.large()]: { ... },
 
-	[from.small.until.large.for.screen()]: { ... },
+	[from.small.until.large]: { ... },
 
 	[from.small.until.large.for.screen()]: { ... },
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ The default is `all`.
 
 ## Usage
 
-### Basics
-
 There are two main ways of applying breakpoints:
 
 - `from` (applies from `breakpoint.value`)

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@
 import { from, until } from 'src-mq'
 
 const styles = {
-	p {
-		[from.small]: { ... },
-		
-		[until.large]: { ... },
-		
-		[from.small.until.large]: { ... },
-		
-		[from.small.until.large.for.screen]: { ... },
-	}
+
+	[from.small]: { ... },
+
+	[until.large]: { ... },
+
+	[from.small.until.large]: { ... },
+
+	[from.small.until.large.for.screen]: { ... },
+
 }
 ```
 
@@ -157,7 +157,7 @@ resetBreakpoints()
 ```
 
 ## Complex queries
-By design, _src-mq_ is limited to media type and min/max-width expressions. 
+By design, _src-mq_ is limited to media type and min/max-width expressions.
 
 To generate more complex queries than this, you can concatenate its output with any valid media feature expressions, for example:
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ const styles = {
 
 ## API
 
-### from
-
-#### `from<breakpoint>`
+### `from<breakpoint>`
 
 Type: `function`
 
@@ -43,7 +41,7 @@ Returns a media query scoped to:
 @media all and (min-width: 30em) { ... }
 ```
 
-#### `from<breakpoint>.for[screen, print, speech]`
+### `from<breakpoint>.for[screen, print, speech]`
 
 Type: `function`
 
@@ -57,9 +55,10 @@ Returns a media query scoped to:
 
 @media screen and (min-width: 30em) { ... }
 ```
-### until
 
-#### `until<breakpoint>`
+<hr />
+
+### `until<breakpoint>`
 
 Type: `function`
 
@@ -73,7 +72,7 @@ Returns a media query scoped to:
 @media all and (max-width: 61.1875em) { ... }
 ```
 
-#### `until<breakpoint>.for[screen, print, speech]`
+### `until<breakpoint>.for[screen, print, speech]`
 
 Type: `function`
 
@@ -88,9 +87,9 @@ Returns a media query scoped to:
 @media screen and (max-width: 61.1875em) { ... }
 ```
 
-### from...until
+<hr />
 
-#### `from<fromBreakpoint>.until<untilBreakpoint>`
+### `from<fromBreakpoint>.until<untilBreakpoint>`
 
 Type: `function`
 
@@ -105,7 +104,7 @@ Returns a media query scoped to:
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-#### `from<fromBreakpoint>.until<untilBreakpoint>.for[screen, print, speech]`
+### `from<fromBreakpoint>.until<untilBreakpoint>.for[screen, print, speech]`
 
 Type: `function`
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const styles = {
 
 ## API
 
-### from
+### `from`
 
 Type: `Object.<breakpoint>`
 
@@ -39,16 +39,19 @@ Restricts styles to media as wide as or wider than __breakpoint__, for example:
 
 When used without further refinement, it yields the media query we've constructed up to this point.
 
-##### until
+#### Optional refinement
 
-Optional refinement of `from.<breakpoint>`. See __until__ below.
+##### `.until`
 
-##### for
+See __.until__ below.
 
-Optional refinement of `from.<breakpoint>`. See __for__ below.
+##### `.for`
 
+See __.for__ below.
 
-### until
+<hr />
+
+### `until` / `.until`
 
 Type: `Object.<breakpoint>`
 
@@ -60,14 +63,22 @@ Restricts styles to media narrower than __breakpoint__, for example:
 @media all and (max-width: 61.1875em) { ... }
 ```
 
+```css
+/* {[from.small.until.large]: { ... }} */
+
+@media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
+```
+
 When used without further refinement, it yields the media query we've constructed up this point.
 
-##### for
+#### Optional refinement
 
-Optional refinement of `fromBreakpointName`. See __for__ below.
+##### `.for`
+
+Optional refinement of `fromBreakpointName`. See __.for__ below.
 
 
-### for
+### `.for`
 
 Type: `Object.(screen | print | speech)`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # src-mq
 
-_Legible breakpoints for JavaScript._
+🤓 Legible breakpoints for JavaScript.
 
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ import {
 } from 'src-mq'
 
 /*
-breakpoints are the default set:
+Breakpoints are the default set:
+
 	- xxSmall (320 pixels)
 	- xSmall (375 pixels)
 	- small (480 pixels)
@@ -103,39 +104,47 @@ breakpoints are the default set:
 	- large (980 pixels)
 	- xLarge (1140 pixels)
 	- xxLarge (1300 pixels)
+
+You can do [from.small.until.medium] etc.
 */
 
 setBreakpoints({ tiny: 1, massive: 10000000 })
 
-/*
-breakpoints have been replaced:
-	- tiny (1 pixel)
-	- massive (10000000 pixels)
-e.g. { [from.tiny.until.massive]: { … } }
-*/
+// Breakpoints have been replaced:
+//
+// 	- tiny (1 pixel)
+// 	- massive (10000000 pixels)
+//
+// Now you can do [from.tiny.until.massive],
+// but not [from.small.until.medium] etc.
+
 
 extendBreakpoints({ infinitesimal: 0.00000001 })
 
-/*
-breakpoints have been extended:
-	- infinitesimal (0.00000001 pixels)
-	- tiny (1 pixel)
-	- massive (10000000 pixels)
-e.g. { [from.infinitesimal.until.tiny]: { … } }
-*/
+// Breakpoints have been extended:
+//
+// 	- infinitesimal (0.00000001 pixels)
+// 	- tiny (1 pixel)
+// 	- massive (10000000 pixels)
+//
+// Now you can do [from.infinitesimal.until.massive] etc.
+
 
 resetBreakpoints()
 
-/*
-breakpoints have been restored to the default set:
-	- xxSmall (320 pixels)
-	- xSmall (375 pixels)
-	- small (480 pixels)
-	- medium (740 pixels)
-	- large (980 pixels)
-	- xLarge (1140 pixels)
-	- xxLarge (1300 pixels)
-*/
+// Breakpoints have been restored to the default set:
+//
+// 	- xxSmall (320 pixels)
+// 	- xSmall (375 pixels)
+// 	- small (480 pixels)
+// 	- medium (740 pixels)
+// 	- large (980 pixels)
+// 	- xLarge (1140 pixels)
+// 	- xxLarge (1300 pixels)
+//
+// Now you can do [from.small.until.medium],
+// but not [from.tiny.until.massive] etc.
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Apply rules for `screen`, `print` or `speech`, rather than the default `all`, fo
 ```css
 /* {[until.large.for.print]: { ... }} */
 
-@media print and (min-width: 30em) { ... }
+@media print and (max-width: 61.1875em) { ... }
 ```
 
 ```css

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ const styles = {
 
 	[until.large()]: { ... },
 
-	[from.small.until.large({media: 'screen')]: { ... },
+	[from.small.until.large.for.screen()]: { ... },
 
-	[from.small.until.large.for('screen')]: { ... },
+	[from.small.until.large.for.screen()]: { ... },
 
 }
 ```
@@ -29,36 +29,42 @@ const styles = {
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of __breakpoint__.
+Returns a media query that limits styles to media with a minimum width of **breakpoint**.
 
 ```css
 /* {[from.small()]: { ... }} */
 
-@media all and (min-width: 30em) { ... }
+@media all and (min-width: 30em) {
+	...;
+}
 ```
 
 #### `until<breakpoint>`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a maximum width of __breakpoint__ − 1px.
+Returns a media query that limits styles to media with a maximum width of **breakpoint** − 1px.
 
 ```css
 /* {[until.large()]: { ... }} */
 
-@media all and (max-width: 61.1875em) { ... }
+@media all and (max-width: 61.1875em) {
+	...;
+}
 ```
 
 #### `from<fromBreakpoint>.until<untilBreakpoint>`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of __fromBreakpoint__ and a maximum width of __untilBreakpoint__ − 1px.
+Returns a media query that limits styles to media with a minimum width of **fromBreakpoint** and a maximum width of **untilBreakpoint** − 1px.
 
 ```css
 /* {[from.small.until.large()]: { ... }} */
 
-@media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
+@media all and (min-width: 30em) and (max-width: 61.1875em) {
+	...;
+}
 ```
 
 #### `.for`
@@ -66,27 +72,32 @@ Returns a media query that limits styles to media with a minimum width of __from
 Type: `function`
 
 - specifies the [media type](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_types)
-- can only be used when chained to a __from__ or __until__
-
+- can only be used when chained to a **from** or **until**
 
 ##### Example
 
 ```css
-/* {[from.small.for('screen')]: { ... }} */
+/* {[from.small.for.screen()]: { ... }} */
 
-@media screen and (min-width: 30em) { ... }
+@media screen and (min-width: 30em) {
+	...;
+}
 ```
 
 ```css
-/* {[until.large.for('print')]: { ... }} */
+/* {[until.large.for.print()]: { ... }} */
 
-@media print and (max-width: 61.1875em) { ... }
+@media print and (max-width: 61.1875em) {
+	...;
+}
 ```
 
 ```css
-/* {[from.small.until.large.for('speech')]: { ... }} */
+/* {[from.small.until.large.for.speech()]: { ... }} */
 
-@media speech and (min-width: 30em) and (max-width: 61.1875em) { ... }
+@media speech and (min-width: 30em) and (max-width: 61.1875em) {
+	...;
+}
 ```
 
 ## Defaults
@@ -94,6 +105,7 @@ Type: `function`
 _src-mq_ provides a reasonable set of defaults:
 
 #### Media type
+
 `all`
 
 #### Breakpoints
@@ -108,17 +120,12 @@ _src-mq_ provides a reasonable set of defaults:
 
 _Breakpoint values are output to CSS as ems, assuming 1em = 16px._
 
-
 ## Overriding breakpoints
 
 If the default breakpoints do not work for you, they can be replaced, extended or restored:
 
 ```js
-import {
-	setBreakpoints,
-	extendBreakpoints,
-	resetBreakpoints,
-} from 'src-mq'
+import { setBreakpoints, extendBreakpoints, resetBreakpoints } from 'src-mq'
 
 // Breakpoints are the default set:
 //
@@ -166,22 +173,24 @@ resetBreakpoints()
 //
 // Now you can do [from.small.until.medium()],
 // but not [from.tiny.until.massive()] etc.
-
 ```
 
 ## Complex queries
+
 By design, _src-mq_ is limited to media type and min/max-width feature expressions.
 
 To generate more complex queries than this, you can concatenate its output with any other valid feature expressions, for example:
 
 ```css
-/* {[from.small() + " and (prefers-reduced-motion: reduce)"]: { ... }} */
+/* {[from.small.for.screen() + " and (prefers-reduced-motion: reduce)"]: { ... }} */
 
-@media all and (min-width: 30em) and (prefers-reduced-motion: reduce) { ... }
+@media screen and (min-width: 30em) and (prefers-reduced-motion: reduce) {
+	...;
+}
 ```
 
-
 ## Acknowledgements
+
 _src-mq_ is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
 
 It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) and that is now being rolled into their [Source Design System](https://github.com/guardian/source-components).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)
+![npm type definitions](https://img.shields.io/npm/types/src-mq)
+
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -12,99 +12,79 @@ import { from, until } from 'src-mq'
 
 const styles = {
 
-	[from.small]: { ... },
+	[from.small()]: { ... },
 
-	[until.large]: { ... },
+	[until.large()]: { ... },
 
-	[from.small.until.large]: { ... },
+	[from.small.until.large({media: 'screen')]: { ... },
 
-	[from.small.until.large.for.screen]: { ... },
+	[from.small.until.large.for('screen')]: { ... },
 
 }
 ```
 
 ## API
 
-### `from`
+#### `from<breakpoint>`
 
-Type: `Object.<breakpoint>`
+Type: `function`
 
-- set a minimum width of __breakpoint__
-- when used as a string, it yields a media query
-
-##### Example
+Returns a media query that limits styles to media with a minimum width of __breakpoint__.
 
 ```css
-/* {[from.small]: { ... }} */
+/* {[from.small()]: { ... }} */
 
 @media all and (min-width: 30em) { ... }
 ```
 
-The scope of the query can be restricted by chaining further refinements:
+#### `until<breakpoint>`
 
-##### `.until`
+Type: `function`
 
-Set a maximum width. See __until__ below.
-
-##### `.for`
-
-Set an explicit media type. See __for__ below.
-
-### `until`
-
-Type: `Object.<breakpoint>`
-
-- set a maximum width of __breakpoint__ − 1px
-- can be chained to a __from__
-- when used as a string, it yields a media query
-
-##### Example
+Returns a media query that limits styles to media with a maximum width of __breakpoint__ − 1px.
 
 ```css
-/* {[until.large]: { ... }} */
+/* {[until.large()]: { ... }} */
 
 @media all and (max-width: 61.1875em) { ... }
 ```
 
+#### `from<fromBreakpoint>.until<untilBreakpoint>`
+
+Type: `function`
+
+Returns a media query that limits styles to media with a minimum width of __fromBreakpoint__ and a maximum width of __untilBreakpoint__ − 1px.
+
 ```css
-/* {[from.small.until.large]: { ... }} */
+/* {[from.small.until.large()]: { ... }} */
 
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-As with __from__, the scope of the query can be restricted by chaining a further refinement:
+#### `.for`
 
-##### `.for`
+Type: `function`
 
-Set an explicit media type. See __for__ below.
-
-
-### `.for`
-
-Type: `Object.(screen | print | speech)`
-
+- specifies the [media type](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_types)
 - can only be used when chained to a __from__ or __until__
-- overrides the default media type (`all`), with any of the following:
-  - `screen`
-  - `print`
-  - `speech`
+
 
 ##### Example
 
 ```css
-/* {[from.small.for.screen]: { ... }} */
+/* {[from.small.for('screen')]: { ... }} */
 
 @media screen and (min-width: 30em) { ... }
 ```
 
 ```css
-/* {[until.large.for.print]: { ... }} */
+/* {[until.large.for('print')]: { ... }} */
 
 @media print and (max-width: 61.1875em) { ... }
 ```
 
 ```css
-/* {[from.small.until.large.for.speech]: { ... }} */
+/* {[from.small.until.large.for('speech')]: { ... }} */
 
 @media speech and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
@@ -150,7 +130,7 @@ import {
 // 	- xLarge (1140 pixels)
 // 	- xxLarge (1300 pixels)
 //
-// You can do [from.small.until.medium] etc.
+// You can do [from.small.until.medium()] etc.
 
 setBreakpoints({ tiny: 1, massive: 10000000 })
 
@@ -159,8 +139,8 @@ setBreakpoints({ tiny: 1, massive: 10000000 })
 // 	- tiny (1 pixel)
 // 	- massive (10000000 pixels)
 //
-// Now you can do [from.tiny.until.massive],
-// but not [from.small.until.medium] etc.
+// Now you can do [from.tiny.until.massive()],
+// but not [from.small.until.medium()] etc.
 
 extendBreakpoints({ infinitesimal: 0.00000001 })
 
@@ -170,7 +150,7 @@ extendBreakpoints({ infinitesimal: 0.00000001 })
 // 	- tiny (1 pixel)
 // 	- massive (10000000 pixels)
 //
-// Now you can do [from.infinitesimal.until.massive] etc.
+// Now you can do [from.infinitesimal.until.massive()] etc.
 
 resetBreakpoints()
 
@@ -184,8 +164,8 @@ resetBreakpoints()
 // 	- xLarge (1140 pixels)
 // 	- xxLarge (1300 pixels)
 //
-// Now you can do [from.small.until.medium],
-// but not [from.tiny.until.massive] etc.
+// Now you can do [from.small.until.medium()],
+// but not [from.tiny.until.massive()] etc.
 
 ```
 
@@ -195,7 +175,7 @@ By design, _src-mq_ is limited to media type and min/max-width feature expressio
 To generate more complex queries than this, you can concatenate its output with any other valid feature expressions, for example:
 
 ```css
-/* {[from.small + " and (prefers-reduced-motion: reduce)"]: { ... }} */
+/* {[from.small() + " and (prefers-reduced-motion: reduce)"]: { ... }} */
 
 @media all and (min-width: 30em) and (prefers-reduced-motion: reduce) { ... }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const styles = {
 
 	[until.large()]: { ... },
 
-	[from.small.until.large]: { ... },
+	[from.small.until.large()]: { ... },
 
 	[from.small.until.large.for.screen()]: { ... },
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Set an explicit media type. See __for__ below.
 
 Type: `Object.(screen | print | speech)`
 
-- can only be used as a refinment of __from__ or __until__
+- can only be used when chained to a __from__ or __until__
 - overrides the default media type (`all`), with any of the following:
- - `screen`
- - `print`
- - `speech`
+  - `screen`
+  - `print`
+  - `speech`
 
 ##### Example
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ resetBreakpoints()
 ## Acknowledgements
 _src-mq_ is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
 
-It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) as part of the new rendering tier, and now being rolled into their [Source Design System](https://github.com/guardian/source-components).
+It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) that is now being rolled into their [Source Design System](https://github.com/guardian/source-components).
 
 Hence the name 💃.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Apply rules until one pixel before __breakpoint__ width, for example:
 
 ### from[breakpoint1].until[breakpoint2]
 
-Apply rules from __breakpoint1__ width, until one pixel before __breakpoint2__ width, for example:
+Apply rules between __breakpoint1__ width and one pixel before __breakpoint2__ width, for example:
 
 ```css
 /* {[from.small.until.large]: { ... }} */
@@ -72,7 +72,7 @@ Apply rules from __breakpoint1__ width, until one pixel before __breakpoint2__ w
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-### [...].for[`screen`, `print`, `speech`]
+### [ ... ].for[`screen`, `print`, `speech`]
 
 Apply rules for `screen`, `print` or `speech`, rather than the default `all`, for example:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://travis-ci.org/src-mq/src-mq.svg?branch=master)](https://travis-ci.org/src-mq/src-mq)
 [![codecov](https://codecov.io/gh/src-mq/src-mq/branch/master/graph/badge.svg)](https://codecov.io/gh/src-mq/src-mq)
 ![npm type definitions](https://img.shields.io/npm/types/src-mq)
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/src-mq)
 
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 ![npm type definitions](https://img.shields.io/npm/types/src-mq)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/src-mq)
 
-
 ### Example
 
 ```js
@@ -28,11 +27,15 @@ const styles = {
 
 ## API
 
+### from
+
 #### `from<breakpoint>`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of **breakpoint**.
+Returns a media query scoped to:
+
+- a minimum width of **breakpoint**
 
 ```scss
 /* {[from.small()]: { ... }} */
@@ -40,23 +43,29 @@ Returns a media query that limits styles to media with a minimum width of **brea
 @media all and (min-width: 30em) { ... }
 ```
 
-#### `from<breakpoint>.for[screen | print | speech]`
+#### `from<breakpoint>.for[screen, print, speech]`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of **breakpoint** and the specified media type.
+Returns a media query scoped to:
+
+- a minimum width of **breakpoint**
+- the specified media type
 
 ```scss
 /* {[from.small.for.screen()]: { ... }} */
 
 @media screen and (min-width: 30em) { ... }
 ```
+### until
 
 #### `until<breakpoint>`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a maximum width of **breakpoint** − 1px.
+Returns a media query scoped to:
+
+- a maximum width of **breakpoint** − 1px
 
 ```scss
 /* {[until.large()]: { ... }} */
@@ -64,11 +73,14 @@ Returns a media query that limits styles to media with a maximum width of **brea
 @media all and (max-width: 61.1875em) { ... }
 ```
 
-#### `until<breakpoint>.for[screen | print | speech]`
+#### `until<breakpoint>.for[screen, print, speech]`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a maximum width of **breakpoint** − 1px and the specified media type.
+Returns a media query scoped to:
+
+- a maximum width of **breakpoint** − 1px
+- the specified media type
 
 ```scss
 /* {[until.large.for.screen()]: { ... }} */
@@ -76,11 +88,16 @@ Returns a media query that limits styles to media with a maximum width of **brea
 @media screen and (max-width: 61.1875em) { ... }
 ```
 
+### from...until
+
 #### `from<fromBreakpoint>.until<untilBreakpoint>`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of **fromBreakpoint** and a maximum width of **untilBreakpoint** − 1px.
+Returns a media query scoped to:
+
+- a minimum width of **fromBreakpoint**
+- a maximum width of **untilBreakpoint** − 1px
 
 ```scss
 /* {[from.small.until.large()]: { ... }} */
@@ -88,11 +105,15 @@ Returns a media query that limits styles to media with a minimum width of **from
 @media all and (min-width: 30em) and (max-width: 61.1875em) { ... }
 ```
 
-#### `from<fromBreakpoint>.until<untilBreakpoint>.for[screen | print | speech]`
+#### `from<fromBreakpoint>.until<untilBreakpoint>.for[screen, print, speech]`
 
 Type: `function`
 
-Returns a media query that limits styles to media with a minimum width of **fromBreakpoint** and a maximum width of **untilBreakpoint** − 1px and the specified media type.
+Returns a media query that limits styles to media:
+
+- a minimum width of **fromBreakpoint**
+- a maximum width of **untilBreakpoint** − 1px
+- the specified media type
 
 ```scss
 /* {[from.small.until.large.for.screen()]: { ... }} */

--- a/README.md
+++ b/README.md
@@ -94,19 +94,17 @@ import {
 	resetBreakpoints,
 } from 'src-mq'
 
-/*
-Breakpoints are the default set:
-
-	- xxSmall (320 pixels)
-	- xSmall (375 pixels)
-	- small (480 pixels)
-	- medium (740 pixels)
-	- large (980 pixels)
-	- xLarge (1140 pixels)
-	- xxLarge (1300 pixels)
-
-You can do [from.small.until.medium] etc.
-*/
+// Breakpoints are the default set:
+//
+// 	- xxSmall (320 pixels)
+// 	- xSmall (375 pixels)
+// 	- small (480 pixels)
+// 	- medium (740 pixels)
+// 	- large (980 pixels)
+// 	- xLarge (1140 pixels)
+// 	- xxLarge (1300 pixels)
+//
+// You can do [from.small.until.medium] etc.
 
 setBreakpoints({ tiny: 1, massive: 10000000 })
 
@@ -118,7 +116,6 @@ setBreakpoints({ tiny: 1, massive: 10000000 })
 // Now you can do [from.tiny.until.massive],
 // but not [from.small.until.medium] etc.
 
-
 extendBreakpoints({ infinitesimal: 0.00000001 })
 
 // Breakpoints have been extended:
@@ -128,7 +125,6 @@ extendBreakpoints({ infinitesimal: 0.00000001 })
 // 	- massive (10000000 pixels)
 //
 // Now you can do [from.infinitesimal.until.massive] etc.
-
 
 resetBreakpoints()
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The default is `all`.
 
 ## Usage
 
-There are two main ways of applying breakpoints:
+There are two ways of applying breakpoints:
 
 - `from` (applies from `breakpoint.value`)
 - `until` (applies until `breakpoint.value - 1`)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Legible breakpoints for JavaScript.
 - `xLarge` (1140 pixels)
 - `xxLarge` (1300 pixels)
 
-Breakpoint values are converted to ems, assuming an em is 16 pixels.
+_n.b. breakpoint values are converted to ems, assuming an em is 16 pixels._
 
 ### @media type
 The default is `all`.
@@ -26,8 +26,8 @@ The default is `all`.
 
 There are two ways of applying breakpoints:
 
-- `from` (applies from `breakpoint.value`)
-- `until` (applies until `breakpoint.value - 1`)
+- `from`
+- `until`
 
 ```js
 import { from, until } from 'src-mq'
@@ -45,6 +45,8 @@ const styles = {
 }
 ```
 
+_n.b. `from`  applies from the breakpoint, `until` applies until the breakpoint minus one pixel._
+
 ### Ranges
 
 `from` can also chain an `until`, to apply styles _between_ two breakpoints:
@@ -61,9 +63,9 @@ const styles = {
 }
 ```
 
-### @media types
+### Custom @media types
 
-Both techniques can chain an optional `for()` method, allowing you set a custom media type for an individual query:
+Both techniques can chain an optional `for()` method, allowing you set a media type per query:
 
 ```js
 import { from, until } from 'src-mq'
@@ -81,9 +83,9 @@ const styles = {
 }
 ```
 
-## Custom breakpoints
+## Using your own breakpoints
 
-Breakpoints can be replaced, extended or restored:
+The default set of breakpoints can be replaced, extended or restored:
 
 ```js
 import {
@@ -137,8 +139,8 @@ breakpoints have been restored to the default set:
 ```
 
 
-## Prior art
-`src-mq` is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
+## Acknowledgements
+_src-mq_ is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).
 
 It's extracted from work [originally done at the Guardian](https://github.com/guardian/dotcom-rendering/pull/21) as part of the new rendering tier, and now being rolled into their [Source Design System](https://github.com/guardian/source-components).
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ resetBreakpoints()
 
 ```
 
+## Complex queries
+By design, _src-mq_ is limited to media type and min/max-width expressions. 
+
+To generate more complex queries than this, you can concatenate its output with any valid media feature expressions, for example:
+
+```css
+/* {[from.small + " and (prefers-reduced-motion: reduce)"]: { ... }} */
+
+@media all and (min-width: 30em) and (prefers-reduced-motion: reduce) { ... }
+```
+
 
 ## Acknowledgements
 _src-mq_ is heavily inspired by [sass-mq](https://github.com/sass-mq/sass-mq).

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
-	transform: {
-		'^.+\\.tsx?$': 'ts-jest',
+	preset: 'ts-jest',
+	globals: {
+		'ts-jest': {
+			isolatedModules: true,
+		},
 	},
-	collectCoverage: true,
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"devDependencies": {
 		"@types/jest": "^24.0.18",
 		"jest": "^24.9.0",
+		"prettier": "^1.18.2",
 		"ts-jest": "^24.0.2",
 		"typescript": "^3.6.2"
 	},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "src-mq",
 	"version": "0.1.0",
-	"description": "Breakpoint media queries in JS",
+	"description": "Lucid breakpoints for JavaScript",
 	"repository": "https://github.com/src-mq/src-mq.git",
 	"license": "MIT",
 	"devDependencies": {

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -3,7 +3,7 @@ import {
 	extendBreakpoints,
 	resetBreakpoints,
 	setBreakpoints,
-} from '../src/config'
+} from './config'
 
 const defaults = {
 	xxSmall: expect.any(Number),

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -21,13 +21,16 @@ describe('breakpoints', () => {
 	test('are defaults without doing anything', () => {
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})
+
 	test('can be extended, replaced and reset', () => {
 		extendBreakpoints(bespoke)
 		expect(breakpoints).toEqual(
 			expect.objectContaining({ ...defaults, ...bespoke }),
 		)
+
 		setBreakpoints(bespoke)
 		expect(breakpoints).toEqual(bespoke)
+
 		resetBreakpoints()
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-const defaults: BreakpointsList = {
+const defaults = {
 	xxSmall: 320,
 	xSmall: 375,
 	small: 480,
@@ -10,11 +10,10 @@ const defaults: BreakpointsList = {
 
 let breakpoints = defaults
 
-export const extendBreakpoints = (userBreakpoints: BreakpointsList) =>
-	(breakpoints = Object.assign({}, userBreakpoints, breakpoints))
+export const extendBreakpoints = userBreakpoints =>
+	(breakpoints = { ...breakpoints, ...userBreakpoints })
 
-export const setBreakpoints = (userBreakpoints: BreakpointsList) =>
-	(breakpoints = userBreakpoints)
+export const setBreakpoints = userBreakpoints => (breakpoints = userBreakpoints)
 
 export const resetBreakpoints = () => (breakpoints = defaults)
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { from, until } from '../src/index'
+import { from, until } from './index'
 
 describe('until', () => {
 	test('is an object that provides breakpoint media queries', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,29 +1,31 @@
 import { from, until } from './index'
 
 describe('until', () => {
-	test('is an object that provides breakpoint media queries', () => {
-		expect(`${until.small}`).toBe('@media all and (max-width: 29.9375em)')
+	test('is a map of functions that return breakpoint media queries', () => {
+		expect(until.small()).toBe('@media all and (max-width: 29.9375em)')
+	})
+
+	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
+		expect(until.small.for.print()).toBe(
+			'@media print and (max-width: 29.9375em)',
+		)
 	})
 })
 
 describe('from', () => {
-	test('is a weird old beast', () => {
-		expect(`${from.small}`).toBe('@media all and (min-width: 30em)')
-		expect(`${from.small.until.medium}`).toBe(
+	test('is a map of functions that return breakpoint media queries', () => {
+		expect(from.small()).toBe('@media all and (min-width: 30em)')
+	})
+
+	test('can chain an `until` map of functions that return breakpoint media queries', () => {
+		expect(from.small.until.medium()).toBe(
 			'@media all and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})
-})
 
-describe('custom media', () => {
-	test('can be applied to `until`', () => {
-		expect(until.small.for('print')).toBe(
-			'@media print and (max-width: 29.9375em)',
-		)
-	})
-	test('can be applied to `from`', () => {
-		expect(from.small.for('print')).toBe('@media print and (min-width: 30em)')
-		expect(from.small.until.medium.for('print')).toBe(
+	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
+		expect(from.small.for.print()).toBe('@media print and (min-width: 30em)')
+		expect(from.small.until.medium.for.print()).toBe(
 			'@media print and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,82 +1,60 @@
 import {
 	breakpoints,
-	Breakpoints,
 	extendBreakpoints,
 	resetBreakpoints,
 	setBreakpoints,
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
-/*
-`from` and `until` are objects with overridden `toString` methods,
-so that they can be coerced into media query strings _or_ provide
-further refinement of the query. this freaky genius was thought up
-by @SiAdcock.
-
-e.g.:
-
-const styles = {
-	[from.small]: {
-		color: 'red'
-	},
-	[from.small.until.large]: {
-		color: 'blue'
-	},
-	[from.small.until.large.for('print')]: {
-		color: 'black'
-	},
-}
-*/
-
-type Until = {
-	[key in Breakpoints]: {
-		toString: () => string
-		for: (mediaType: string) => string
-	}
-}
-
-type From = {
-	[key in Breakpoints]: {
-		toString: () => string
-		until: Until
-		for: (mediaType: string) => string
-	}
-}
-
 export const until = Object.entries(breakpoints).reduce(
-	(untils, [untilName, untilWidth]) => ({
-		[untilName]: {
-			toString: () => untilQuery(untilWidth),
-			for: (mediaType: string) => untilQuery(untilWidth, mediaType),
-		},
-		...untils,
-	}),
+	(untils, [untilName, untilWidth]) => {
+		const getQuery = (): MediaQuery => untilQuery(untilWidth)
+		getQuery.for = {
+			screen: (): MediaQuery => untilQuery(untilWidth, 'screen'),
+			print: (): MediaQuery => untilQuery(untilWidth, 'print'),
+			speech: (): MediaQuery => untilQuery(untilWidth, 'speech'),
+		}
+		return {
+			[untilName]: getQuery,
+			...untils,
+		}
+	},
 	{},
-) as Until
+)
 
 export const from = Object.entries(breakpoints).reduce(
-	(froms, [fromName, fromWidth], i) => ({
-		[fromName]: {
-			toString: () => fromQuery(fromWidth),
-			for: (mediaType: string) => fromQuery(fromWidth, mediaType),
-			until: Object.entries(breakpoints)
-				.splice(i + 1)
-				.reduce(
-					(untils, [untilName, untilWidth], i) => ({
-						[untilName]: {
-							toString: () => fromUntilQuery(fromWidth, untilWidth),
-							for: (mediaType: string) =>
-								fromUntilQuery(fromWidth, untilWidth, mediaType),
-						},
-						...untils,
-					}),
-					{},
-				),
-		},
-		...froms,
-	}),
+	(froms, [fromName, fromWidth], i) => {
+		const getFromQuery = (): MediaQuery => fromQuery(fromWidth)
+		;(getFromQuery.until = Object.entries(breakpoints)
+			.splice(i + 1)
+			.reduce((untils, [untilName, untilWidth], i) => {
+				const getUntilQuery = (): MediaQuery =>
+					fromUntilQuery(fromWidth, untilWidth)
+				getUntilQuery.for = {
+					screen: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'screen'),
+					print: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'print'),
+					speech: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'speech'),
+				}
+				return {
+					[untilName]: getUntilQuery,
+					...untils,
+				}
+			}, {})),
+			(getFromQuery.for = {
+				screen: (): MediaQuery => fromQuery(fromWidth, 'screen'),
+				print: (): MediaQuery => fromQuery(fromWidth, 'print'),
+				speech: (): MediaQuery => fromQuery(fromWidth, 'speech'),
+			})
+		return {
+			[fromName]: getFromQuery,
+			...froms,
+		}
+	},
 
 	{},
-) as From
+)
 
 export { resetBreakpoints, setBreakpoints, extendBreakpoints }

--- a/src/media-queries.spec.ts
+++ b/src/media-queries.spec.ts
@@ -1,4 +1,4 @@
-import { fromQuery, fromUntilQuery, untilQuery } from '../src/media-queries'
+import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
 describe('fromQuery', () => {
 	test('generates min-widths without media type', () => {

--- a/src/media-queries.ts
+++ b/src/media-queries.ts
@@ -1,18 +1,19 @@
-const asEms = (pixels: number) => `${pixels / 16}em`
+const asEms = (pixels: number): string => `${pixels / 16}em`
 
-const query = (mediaType: string = 'all') => `@media ${mediaType}`
+const query = (mediaType: MediaType = 'all'): string => `@media ${mediaType}`
 
-const minWidth = (width: number) => `(min-width: ${asEms(width)})`
-const maxWidth = (width: number) => `(max-width: ${asEms(width - 1)})`
+const minWidth = (width: number): string => `(min-width: ${asEms(width)})`
+const maxWidth = (width: number): string => `(max-width: ${asEms(width - 1)})`
 
-export const fromQuery = (from: number, mediaType?: string) =>
+export const fromQuery = (from: number, mediaType?: MediaType): MediaQuery =>
 	`${query(mediaType)} and ${minWidth(from)}`
 
-export const untilQuery = (until: number, mediaType?: string) =>
+export const untilQuery = (until: number, mediaType?: MediaType): MediaQuery =>
 	`${query(mediaType)} and ${maxWidth(until)}`
 
 export const fromUntilQuery = (
 	from: number,
 	until: number,
-	mediaType?: string,
-) => `${query(mediaType)} and ${minWidth(from)} and ${maxWidth(until)}`
+	mediaType?: MediaType,
+): MediaQuery =>
+	`${query(mediaType)} and ${minWidth(from)} and ${maxWidth(until)}`

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,2 @@
-type BreakpointsList = {
-	[prop: string]: number
-}
-
-// type Breakpoints = keyof typeof breakpoints
+type MediaType = 'screen' | 'speech' | 'print' | 'all'
+type MediaQuery = string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,6 +2667,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"


### PR DESCRIPTION
Sadly, [implicitly calling `toString` won't work in tagged template literals](https://github.com/guardian/source-components/pull/7), since coercing the object to strings is not guaranteed - the author of the tag decides what to do.

This updates the tests to call each query statement explicitly, and gets the passing.

It also removes most types, since they're tricky and need looking at in a separate pass