### PR TITLE
API offers explicit function calls and implicit when coerced into string

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-    trailingComma: 'all',
-    semi: false,
-    singleQuote: true,
-    useTabs: true,
-};
+	trailingComma: 'all',
+	semi: false,
+	singleQuote: true,
+	useTabs: true,
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ branches:
 script:
   - yarn lint
   - yarn global add codecov
-  - yarn test --ci
+  - yarn test --ci --coverage
 after_success:
   - codecov -f coverage/*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   only:
     - master
 script:
-  - yarn lint
+  # - yarn lint
   - yarn global add codecov
   - yarn test --ci --coverage
 after_success:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ const styles = {
 }
 ```
 
-If you're using _src-mq_ in a tagged template, you will need to explicitly call it each time. Here is an example using Emotion's `css`:
+If you're using _src-mq_ in a tagged template, you will need to explicitly call it each time. 
+
+Here is an example using [Emotion](https://emotion.sh)'s `css`:
 
 ```js
 import { from, until } from 'src-mq'
 import css from 'emotion'
 
-const styles = css`
+const className = css`
 	${from.small()} { ... },
 
 	${until.large()} { ... },

--- a/README.md
+++ b/README.md
@@ -13,16 +13,31 @@
 import { from, until } from 'src-mq'
 
 const styles = {
+	[from.small]: { ... },
 
-	[from.small()]: { ... },
+	[until.large]: { ... },
 
-	[until.large()]: { ... },
+	[from.small.until.large]: { ... },
 
-	[from.small.until.large()]: { ... },
-
-	[from.small.until.large.for.screen()]: { ... },
-
+	[from.small.until.large.for.screen]: { ... },
 }
+```
+
+If you're using _src-mq_ in a tagged template, you will need to explicitly call it each time. Here is an example using Emotion's `css`:
+
+```js
+import { from, until } from 'src-mq'
+import css from 'emotion'
+
+const styles = css`
+	${from.small()} { ... },
+
+	${until.large()} { ... },
+
+	${from.small.until.large()} { ... },
+
+	${from.small.until.large.for.screen()} { ... },
+`
 ```
 
 ## API

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
-	transform: {
-		'^.+\\.tsx?$': 'ts-jest',
+	preset: 'ts-jest',
+	globals: {
+		'ts-jest': {
+			isolatedModules: true,
+		},
 	},
-	collectCoverage: true,
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"devDependencies": {
 		"@types/jest": "^24.0.18",
 		"jest": "^24.9.0",
+		"prettier": "^1.18.2",
 		"ts-jest": "^24.0.2",
 		"typescript": "^3.6.2"
 	},

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -3,7 +3,7 @@ import {
 	extendBreakpoints,
 	resetBreakpoints,
 	setBreakpoints,
-} from '../src/config'
+} from './config'
 
 const defaults = {
 	xxSmall: expect.any(Number),

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -21,13 +21,16 @@ describe('breakpoints', () => {
 	test('are defaults without doing anything', () => {
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})
+
 	test('can be extended, replaced and reset', () => {
 		extendBreakpoints(bespoke)
 		expect(breakpoints).toEqual(
 			expect.objectContaining({ ...defaults, ...bespoke }),
 		)
+
 		setBreakpoints(bespoke)
 		expect(breakpoints).toEqual(bespoke)
+
 		resetBreakpoints()
 		expect(breakpoints).toEqual(expect.objectContaining(defaults))
 	})

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-const defaults: BreakpointsList = {
+const defaults = {
 	xxSmall: 320,
 	xSmall: 375,
 	small: 480,
@@ -10,11 +10,10 @@ const defaults: BreakpointsList = {
 
 let breakpoints = defaults
 
-export const extendBreakpoints = (userBreakpoints: BreakpointsList) =>
-	(breakpoints = Object.assign({}, userBreakpoints, breakpoints))
+export const extendBreakpoints = userBreakpoints =>
+	(breakpoints = { ...breakpoints, ...userBreakpoints })
 
-export const setBreakpoints = (userBreakpoints: BreakpointsList) =>
-	(breakpoints = userBreakpoints)
+export const setBreakpoints = userBreakpoints => (breakpoints = userBreakpoints)
 
 export const resetBreakpoints = () => (breakpoints = defaults)
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { from, until } from '../src/index'
+import { from, until } from './index'
 
 describe('until', () => {
 	test('is an object that provides breakpoint media queries', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,29 +1,31 @@
 import { from, until } from './index'
 
 describe('until', () => {
-	test('is an object that provides breakpoint media queries', () => {
-		expect(`${until.small}`).toBe('@media all and (max-width: 29.9375em)')
+	test('is a map of functions that return breakpoint media queries', () => {
+		expect(until.small()).toBe('@media all and (max-width: 29.9375em)')
+	})
+
+	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
+		expect(until.small.for.print()).toBe(
+			'@media print and (max-width: 29.9375em)',
+		)
 	})
 })
 
 describe('from', () => {
-	test('is a weird old beast', () => {
-		expect(`${from.small}`).toBe('@media all and (min-width: 30em)')
-		expect(`${from.small.until.medium}`).toBe(
+	test('is a map of functions that return breakpoint media queries', () => {
+		expect(from.small()).toBe('@media all and (min-width: 30em)')
+	})
+
+	test('can chain an `until` map of functions that return breakpoint media queries', () => {
+		expect(from.small.until.medium()).toBe(
 			'@media all and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})
-})
 
-describe('custom media', () => {
-	test('can be applied to `until`', () => {
-		expect(until.small.for('print')).toBe(
-			'@media print and (max-width: 29.9375em)',
-		)
-	})
-	test('can be applied to `from`', () => {
-		expect(from.small.for('print')).toBe('@media print and (min-width: 30em)')
-		expect(from.small.until.medium.for('print')).toBe(
+	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
+		expect(from.small.for.print()).toBe('@media print and (min-width: 30em)')
+		expect(from.small.until.medium.for.print()).toBe(
 			'@media print and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,9 @@ describe('until', () => {
 	test('is a map of functions that return breakpoint media queries', () => {
 		expect(until.small()).toBe('@media all and (max-width: 29.9375em)')
 	})
+	test('is a map of functions that return breakpoint media queries when coerced into a string', () => {
+		expect(String(until.small)).toBe('@media all and (max-width: 29.9375em)')
+	})
 
 	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
 		expect(until.small.for.print()).toBe(
@@ -16,6 +19,9 @@ describe('from', () => {
 	test('is a map of functions that return breakpoint media queries', () => {
 		expect(from.small()).toBe('@media all and (min-width: 30em)')
 	})
+	test('is a map of functions that return breakpoint media queries when coerced into a string', () => {
+		expect(String(from.small)).toBe('@media all and (min-width: 30em)')
+	})
 
 	test('can chain an `until` map of functions that return breakpoint media queries', () => {
 		expect(from.small.until.medium()).toBe(
@@ -23,9 +29,24 @@ describe('from', () => {
 		)
 	})
 
+	test('can chain an `until` map of functions that return breakpoint media queries when coerced into a string', () => {
+		expect(String(from.small.until.medium)).toBe(
+			'@media all and (min-width: 30em) and (max-width: 46.1875em)',
+		)
+	})
+
 	test('can chain a `for` map of functions that return media queries scoped by media type', () => {
 		expect(from.small.for.print()).toBe('@media print and (min-width: 30em)')
 		expect(from.small.until.medium.for.print()).toBe(
+			'@media print and (min-width: 30em) and (max-width: 46.1875em)',
+		)
+	})
+
+	test('can chain a `for` map of functions that return media queries scoped by media type when coerced into a string', () => {
+		expect(String(from.small.for.print)).toBe(
+			'@media print and (min-width: 30em)',
+		)
+		expect(String(from.small.until.medium.for.print)).toBe(
 			'@media print and (min-width: 30em) and (max-width: 46.1875em)',
 		)
 	})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,82 +1,60 @@
 import {
 	breakpoints,
-	Breakpoints,
 	extendBreakpoints,
 	resetBreakpoints,
 	setBreakpoints,
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
-/*
-`from` and `until` are objects with overridden `toString` methods,
-so that they can be coerced into media query strings _or_ provide
-further refinement of the query. this freaky genius was thought up
-by @SiAdcock.
-
-e.g.:
-
-const styles = {
-	[from.small]: {
-		color: 'red'
-	},
-	[from.small.until.large]: {
-		color: 'blue'
-	},
-	[from.small.until.large.for('print')]: {
-		color: 'black'
-	},
-}
-*/
-
-type Until = {
-	[key in Breakpoints]: {
-		toString: () => string
-		for: (mediaType: string) => string
-	}
-}
-
-type From = {
-	[key in Breakpoints]: {
-		toString: () => string
-		until: Until
-		for: (mediaType: string) => string
-	}
-}
-
 export const until = Object.entries(breakpoints).reduce(
-	(untils, [untilName, untilWidth]) => ({
-		[untilName]: {
-			toString: () => untilQuery(untilWidth),
-			for: (mediaType: string) => untilQuery(untilWidth, mediaType),
-		},
-		...untils,
-	}),
+	(untils, [untilName, untilWidth]) => {
+		const getQuery = (): MediaQuery => untilQuery(untilWidth)
+		getQuery.for = {
+			screen: (): MediaQuery => untilQuery(untilWidth, 'screen'),
+			print: (): MediaQuery => untilQuery(untilWidth, 'print'),
+			speech: (): MediaQuery => untilQuery(untilWidth, 'speech'),
+		}
+		return {
+			[untilName]: getQuery,
+			...untils,
+		}
+	},
 	{},
-) as Until
+)
 
 export const from = Object.entries(breakpoints).reduce(
-	(froms, [fromName, fromWidth], i) => ({
-		[fromName]: {
-			toString: () => fromQuery(fromWidth),
-			for: (mediaType: string) => fromQuery(fromWidth, mediaType),
-			until: Object.entries(breakpoints)
-				.splice(i + 1)
-				.reduce(
-					(untils, [untilName, untilWidth], i) => ({
-						[untilName]: {
-							toString: () => fromUntilQuery(fromWidth, untilWidth),
-							for: (mediaType: string) =>
-								fromUntilQuery(fromWidth, untilWidth, mediaType),
-						},
-						...untils,
-					}),
-					{},
-				),
-		},
-		...froms,
-	}),
+	(froms, [fromName, fromWidth], i) => {
+		const getFromQuery = (): MediaQuery => fromQuery(fromWidth)
+		;(getFromQuery.until = Object.entries(breakpoints)
+			.splice(i + 1)
+			.reduce((untils, [untilName, untilWidth], i) => {
+				const getUntilQuery = (): MediaQuery =>
+					fromUntilQuery(fromWidth, untilWidth)
+				getUntilQuery.for = {
+					screen: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'screen'),
+					print: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'print'),
+					speech: (): MediaQuery =>
+						fromUntilQuery(fromWidth, untilWidth, 'speech'),
+				}
+				return {
+					[untilName]: getUntilQuery,
+					...untils,
+				}
+			}, {})),
+			(getFromQuery.for = {
+				screen: (): MediaQuery => fromQuery(fromWidth, 'screen'),
+				print: (): MediaQuery => fromQuery(fromWidth, 'print'),
+				speech: (): MediaQuery => fromQuery(fromWidth, 'speech'),
+			})
+		return {
+			[fromName]: getFromQuery,
+			...froms,
+		}
+	},
 
 	{},
-) as From
+)
 
 export { resetBreakpoints, setBreakpoints, extendBreakpoints }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,16 @@ import {
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
+const setMediaType = fn => ({
+	screen: fn.bind(null, 'screen'),
+	print: fn.bind(null, 'print'),
+	speech: fn.bind(null, 'speech'),
+})
+
 export const until = Object.entries(breakpoints).reduce(
 	(untils, [untilName, untilWidth]) => {
-		const getQuery = (): MediaQuery => untilQuery(untilWidth)
-		getQuery.for = {
-			screen: (): MediaQuery => untilQuery(untilWidth, 'screen'),
-			print: (): MediaQuery => untilQuery(untilWidth, 'print'),
-			speech: (): MediaQuery => untilQuery(untilWidth, 'speech'),
-		}
+		const getQuery = () => untilQuery(untilWidth)
+		getQuery.for = setMediaType(mediaType => untilQuery(untilWidth, mediaType))
 		return {
 			[untilName]: getQuery,
 			...untils,
@@ -24,30 +26,23 @@ export const until = Object.entries(breakpoints).reduce(
 
 export const from = Object.entries(breakpoints).reduce(
 	(froms, [fromName, fromWidth], i) => {
-		const getFromQuery = (): MediaQuery => fromQuery(fromWidth)
-		;(getFromQuery.until = Object.entries(breakpoints)
+		const getFromQuery = () => fromQuery(fromWidth)
+		getFromQuery.until = Object.entries(breakpoints)
 			.splice(i + 1)
 			.reduce((untils, [untilName, untilWidth], i) => {
-				const getUntilQuery = (): MediaQuery =>
-					fromUntilQuery(fromWidth, untilWidth)
-				getUntilQuery.for = {
-					screen: (): MediaQuery =>
-						fromUntilQuery(fromWidth, untilWidth, 'screen'),
-					print: (): MediaQuery =>
-						fromUntilQuery(fromWidth, untilWidth, 'print'),
-					speech: (): MediaQuery =>
-						fromUntilQuery(fromWidth, untilWidth, 'speech'),
-				}
+				const getUntilQuery = () => fromUntilQuery(fromWidth, untilWidth)
+				getUntilQuery.for = setMediaType(mediaType =>
+					fromUntilQuery(fromWidth, untilWidth, mediaType),
+				)
+
 				return {
 					[untilName]: getUntilQuery,
 					...untils,
 				}
-			}, {})),
-			(getFromQuery.for = {
-				screen: (): MediaQuery => fromQuery(fromWidth, 'screen'),
-				print: (): MediaQuery => fromQuery(fromWidth, 'print'),
-				speech: (): MediaQuery => fromQuery(fromWidth, 'speech'),
-			})
+			}, {})
+		getFromQuery.for = setMediaType(mediaType =>
+			fromQuery(fromWidth, mediaType),
+		)
 		return {
 			[fromName]: getFromQuery,
 			...froms,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,20 @@ import {
 } from './config'
 import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
-const setMediaType = fn => ({
-	screen: fn.bind(null, 'screen'),
-	print: fn.bind(null, 'print'),
-	speech: fn.bind(null, 'speech'),
-})
+const setMediaType = fn =>
+	['screen', 'print', 'speech'].reduce((mediaTypes, mediaType) => {
+		const typeQuery = fn.bind(null, mediaType)
+		typeQuery.toString = typeQuery
+		return {
+			...mediaTypes,
+			[mediaType]: typeQuery,
+		}
+	}, {})
 
 export const until = Object.entries(breakpoints).reduce(
 	(untils, [untilName, untilWidth]) => {
 		const getQuery = () => untilQuery(untilWidth)
+		getQuery.toString = getQuery
 		getQuery.for = setMediaType(mediaType => untilQuery(untilWidth, mediaType))
 		return {
 			[untilName]: getQuery,
@@ -27,16 +32,18 @@ export const until = Object.entries(breakpoints).reduce(
 export const from = Object.entries(breakpoints).reduce(
 	(froms, [fromName, fromWidth], i) => {
 		const getFromQuery = () => fromQuery(fromWidth)
+		getFromQuery.toString = getFromQuery
 		getFromQuery.until = Object.entries(breakpoints)
 			.splice(i + 1)
 			.reduce((untils, [untilName, untilWidth], i) => {
-				const getUntilQuery = () => fromUntilQuery(fromWidth, untilWidth)
-				getUntilQuery.for = setMediaType(mediaType =>
+				const getFromUntilQuery = () => fromUntilQuery(fromWidth, untilWidth)
+				getFromUntilQuery.toString = getFromUntilQuery
+				getFromUntilQuery.for = setMediaType(mediaType =>
 					fromUntilQuery(fromWidth, untilWidth, mediaType),
 				)
 
 				return {
-					[untilName]: getUntilQuery,
+					[untilName]: getFromUntilQuery,
 					...untils,
 				}
 			}, {})

--- a/src/media-queries.spec.ts
+++ b/src/media-queries.spec.ts
@@ -1,4 +1,4 @@
-import { fromQuery, fromUntilQuery, untilQuery } from '../src/media-queries'
+import { fromQuery, fromUntilQuery, untilQuery } from './media-queries'
 
 describe('fromQuery', () => {
 	test('generates min-widths without media type', () => {

--- a/src/media-queries.ts
+++ b/src/media-queries.ts
@@ -1,18 +1,19 @@
-const asEms = (pixels: number) => `${pixels / 16}em`
+const asEms = (pixels: number): string => `${pixels / 16}em`
 
-const query = (mediaType: string = 'all') => `@media ${mediaType}`
+const query = (mediaType: MediaType = 'all'): string => `@media ${mediaType}`
 
-const minWidth = (width: number) => `(min-width: ${asEms(width)})`
-const maxWidth = (width: number) => `(max-width: ${asEms(width - 1)})`
+const minWidth = (width: number): string => `(min-width: ${asEms(width)})`
+const maxWidth = (width: number): string => `(max-width: ${asEms(width - 1)})`
 
-export const fromQuery = (from: number, mediaType?: string) =>
+export const fromQuery = (from: number, mediaType?: MediaType): MediaQuery =>
 	`${query(mediaType)} and ${minWidth(from)}`
 
-export const untilQuery = (until: number, mediaType?: string) =>
+export const untilQuery = (until: number, mediaType?: MediaType): MediaQuery =>
 	`${query(mediaType)} and ${maxWidth(until)}`
 
 export const fromUntilQuery = (
 	from: number,
 	until: number,
-	mediaType?: string,
-) => `${query(mediaType)} and ${minWidth(from)} and ${maxWidth(until)}`
+	mediaType?: MediaType,
+): MediaQuery =>
+	`${query(mediaType)} and ${minWidth(from)} and ${maxWidth(until)}`

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,2 @@
-type BreakpointsList = {
-	[prop: string]: number
-}
-
-// type Breakpoints = keyof typeof breakpoints
+type MediaType = 'screen' | 'speech' | 'print' | 'all'
+type MediaQuery = string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,6 +2667,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"


### PR DESCRIPTION
Sadly, [implicitly calling `toString` won't work in tagged template literals](https://github.com/guardian/source-components/pull/7), since coercing the object to strings is not guaranteed - the author of the tag decides what to do.

This adds an explicit function option, while maintaining the overridden `toString` which can continue to be used outside tagged templates.

It also 

- removes most types, since they're tricky and need looking at in a separate pass
- colocates the tests with their modules